### PR TITLE
API's pricelist throws different slabs

### DIFF
--- a/modules/addons/namesrs_price/namesrs_price.php
+++ b/modules/addons/namesrs_price/namesrs_price.php
@@ -93,6 +93,7 @@ function namesrs_price_output($vars)
     $price_currencies = array();
     if(is_array($result['pricelist']['domains'])) foreach($result['pricelist']['domains'] as $domain => $priceObj)
     {
+      if (!$priceObj['Retail']) continue;
       $pricelist[$domain] = $priceObj['Retail'];
       $item = &$priceObj['Retail']['Registration'];
       $cur = $item['currency'];


### PR DESCRIPTION
When you request the pricelist from the API it returns domains with not only "Retail" slab but "Reseller Class N" (depending on the reseller perhaps), which causes the domain importer to stop working. By adding that check, we make sure we're getting a the Retail slab only, unless others need to be considered?